### PR TITLE
Minor correction to Terms Filter Lookup Query page

### DIFF
--- a/a-news-feed-with-elasticsearch/index.html
+++ b/a-news-feed-with-elasticsearch/index.html
@@ -298,7 +298,7 @@ curl -XPOST "http://localhost:9200/newsfeed/news/_search" -d
                     "producerId": {
                         "index": "newsfeed_consumer_network",
                         "type": "consumer_network",
-                        "id": "urn:viadeo:network:me",
+                        "id": "urn:viadeo:member:me",
                         "path": "producerIds"
                     }
                 }


### PR DESCRIPTION
Changed the id of document used in the example Elasticsearch terms lookup filter to match the one specified on earlier page "Consumer Network Document"
